### PR TITLE
fix: 보드의 버튼 크기 고정, text 줄 간격 수정

### DIFF
--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -4,15 +4,9 @@ import Button, { Feature, Color } from "../Button/Button";
 const Board = ({ children, buttonText, buttonHandler }) => {
   return (
     <BoardStyle>
-      <div style={{ width: "300px" }}>
-        <Button
-          feature={Feature.NONE}
-          color={Color.BLUE}
-          handler={buttonHandler}
-        >
-          {buttonText}
-        </Button>
-      </div>
+      <Button feature={Feature.NONE} color={Color.BLUE} handler={buttonHandler}>
+        {buttonText}
+      </Button>
       <BoardTextStyle>{children}</BoardTextStyle>
     </BoardStyle>
   );

--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -4,9 +4,15 @@ import Button, { Feature, Color } from "../Button/Button";
 const Board = ({ children, buttonText, buttonHandler }) => {
   return (
     <BoardStyle>
-      <Button feature={Feature.NONE} color={Color.BLUE} handler={buttonHandler}>
-        {buttonText}
-      </Button>
+      <div style={{ width: "300px" }}>
+        <Button
+          feature={Feature.NONE}
+          color={Color.BLUE}
+          handler={buttonHandler}
+        >
+          {buttonText}
+        </Button>
+      </div>
       <BoardTextStyle>{children}</BoardTextStyle>
     </BoardStyle>
   );

--- a/src/components/Board/style.js
+++ b/src/components/Board/style.js
@@ -21,4 +21,5 @@ export const BoardTextStyle = styled.text`
   flex: 1;
   letter-spacing: -1.05px;
   line-height: 1.5;
+  margin: 0px 50px;
 `;

--- a/src/components/Board/style.js
+++ b/src/components/Board/style.js
@@ -20,5 +20,5 @@ export const BoardTextStyle = styled.text`
   font-size: 17px;
   flex: 1;
   letter-spacing: -1.05px;
-  line-height: normal;
+  line-height: 1.5;
 `;


### PR DESCRIPTION
**1. 보드의 버튼 크기 고정**
버튼이랑 보드 width가 모두 고정 크기가 아니라 auto여서 내부 글자 길이에 따라 영향을 받는 상태였다
(그래서 보드 width가 애매해 보였음)
-> 그래서 보드에 있는 버튼 크기만 고정시켰다(피그마와 비슷해보이게)

**2. 보드의 text 줄 간격 수정**
너무 줄 간격이 붙어있어 보여서, 피그마와 비슷해보이게 조금 넓혔다