### PR TITLE
feat: 이력서 추가 화면 구성, ImageText 컴포넌트 추가

### DIFF
--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -50,7 +50,7 @@ export const ButtonFlexibleStyle = styled.button`
   color: rgba(68, 68, 68, 0.7);
   height: fit-content;
 
-  letter-spacing: -1.2px;
+  letter-spacing: -0.5px;
   font-weight: 700;
   line-height: 1;
   cursor: pointer;

--- a/src/components/ImageText/ImageText.js
+++ b/src/components/ImageText/ImageText.js
@@ -1,0 +1,19 @@
+import { InnerStyle, WrapperStyle, IconImage, Description } from "./style";
+
+export const ImageTextColor = {
+  BLUE: "#3D4371",
+  WHITE: "#FFFFFF",
+};
+
+const ImageText = ({ imageUrl, color, children }) => {
+  return (
+    <InnerStyle>
+      <WrapperStyle>
+        <IconImage src={imageUrl} alt="IconImage" />
+        <Description color={color}>{children}</Description>
+      </WrapperStyle>
+    </InnerStyle>
+  );
+};
+
+export default ImageText;

--- a/src/components/ImageText/style.js
+++ b/src/components/ImageText/style.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+export const WrapperStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: fit-content;
+  align-items: center;
+`;
+
+export const IconImage = styled.img`
+  width: 40px;
+`;
+
+export const Description = styled.div`
+  color: ${(props) => `${props.color}`};
+  text-align: center;
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: -0.4px;
+`;
+
+export const InnerStyle = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -8,25 +8,19 @@ export const InputColor = {
 
 Object.freeze(InputColor);
 
-const Input = ({
-  type,
-  label,
-  value,
-  onChangeHandler,
-  isError,
-  color,
-  maxLength,
-}) => {
+const Input = ({ type, label, value, onChange, isError, color, maxLength }) => {
   const [currentValue, setCurrentValue] = useState(value || "");
+  if (!maxLength) maxLength = 100;
 
   const handleChange = (e) => {
     const inputValue = e.target.value.slice(0, maxLength);
     setCurrentValue(inputValue);
 
-    if (onChangeHandler) {
-      onChangeHandler(inputValue);
+    if (onChange) {
+      onChange(inputValue);
     }
   };
+
   return (
     <WrapperStyle>
       <LabelStyle>{label}</LabelStyle>

--- a/src/components/Input/style.js
+++ b/src/components/Input/style.js
@@ -26,6 +26,7 @@ export const WrapperStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
 `;
 
 export const LabelStyle = styled.span`
@@ -34,5 +35,5 @@ export const LabelStyle = styled.span`
   font-size: 14px;
   font-weight: 400;
   line-height: normal;
-  letter-spacing: -0.8px;
+  letter-spacing: -0.2px;
 `;

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -12,19 +12,21 @@ const Textarea = ({
   type,
   label,
   value,
-  onChangeHandler,
+  onChange,
   isError,
   color,
   maxLength,
+  readOnly,
 }) => {
   const [currentValue, setCurrentValue] = useState(value || "");
+  if (!readOnly) readOnly = false;
 
   const handleChange = (e) => {
     const inputValue = e.target.value.slice(0, maxLength);
     setCurrentValue(inputValue);
 
-    if (onChangeHandler) {
-      onChangeHandler(inputValue);
+    if (onChange) {
+      onChange(inputValue);
     }
   };
 
@@ -39,6 +41,7 @@ const Textarea = ({
         isError={isError}
         color={color}
         maxLength={maxLength}
+        readOnly={readOnly}
       />
     </WrapperStyle>
   );

--- a/src/components/Textarea/style.js
+++ b/src/components/Textarea/style.js
@@ -48,6 +48,7 @@ export const WrapperStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
 `;
 
 export const LabelStyle = styled.span`

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Header from "../components/Header";
 import MainBanner from "../components/MainBanner/MainBanner";
@@ -12,26 +12,29 @@ import Textarea, { TextareaColor } from "../components/Textarea/Textarea";
 import ImageText, { ImageTextColor } from "../components/ImageText/ImageText";
 
 const ProjectForm = (props) => {
-  const { setAddMode } = props;
+  const { setAddMode, project, setProject } = props;
 
   const [name, setName] = useState("");
   const [summary, setSummary] = useState("");
   const [description, setDescription] = useState("");
   const [techStack, setTechStack] = useState([]);
 
-  function onChangeName(e) {
-    setName(e.target.value);
-  }
-
-  function onChangeSummary(e) {
-    setSummary(e.target.value);
-  }
-
-  function onChangeDescription(e) {
-    setDescription(e.target.value);
-  }
-
   function onClickCloseButton() {
+    setAddMode(false);
+  }
+
+  function addProject() {
+    const newId = project.length + 1;
+
+    const newProject = {
+      id: newId,
+      name: name,
+      summary: summary,
+      description: description,
+      techStack: techStack,
+    };
+
+    setProject([...project, newProject]);
     setAddMode(false);
   }
 
@@ -47,33 +50,40 @@ const ProjectForm = (props) => {
         label="1. 프로젝트 이름을 입력해주세요"
         color={InputColor.WHITE}
         value={name}
-        handler={onChangeName}
+        onChange={setName}
       />
       <Input
         label="2. 프로젝트 한 줄 설명을 입력해주세요"
         color={InputColor.WHITE}
         value={summary}
-        handler={onChangeSummary}
+        onChange={setSummary}
       />
-      <div
-        style={{
-          display: "flex",
-          gap: "12px",
-          width: "100%",
-          alignItems: "center",
-        }}
-      >
-        <LabelStyle>3. 사용 스택을 선택해주세요</LabelStyle>
-        <Button feature={ButtonFeature.FLEXIBLE}>스택 검색</Button>
-      </div>
+      <WrapperStyle>
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+            width: "100%",
+            alignItems: "center",
+          }}
+        >
+          <LabelStyle>3. 사용 스택을 선택해주세요</LabelStyle>
+          <Button feature={ButtonFeature.FLEXIBLE}>스택 검색</Button>
+        </div>
+        <NoContentContainer>선택한 스택이 없습니다.</NoContentContainer>
+      </WrapperStyle>
       <Textarea
         label="4. 상세 업무 및 성과를 입력해주세요"
         color={TextareaColor.WHITE}
         value={description}
-        handler={onChangeDescription}
+        onChange={setDescription}
       />
       <div style={{ width: "300px" }}>
-        <Button feature={ButtonFeature.NONE} color={ButtonColor.BLUE}>
+        <Button
+          feature={ButtonFeature.NONE}
+          color={ButtonColor.BLUE}
+          handler={addProject}
+        >
           프로젝트 추가하기
         </Button>
       </div>
@@ -99,16 +109,57 @@ const ProjectContainer = (props) => {
         </Button>
       </TitleWrapper>
       {project.length === 0 && !addMode ? (
-        <NoProjectContainer>
+        <NoContentContainer>
           입력된 사이드 프로젝트가 없습니다.
-        </NoProjectContainer>
+        </NoContentContainer>
       ) : (
         <ProjectWrapperStyle>
           {addMode && (
             <GrayBoxContainer>
-              <ProjectForm setAddMode={setAddMode} />
+              <ProjectForm
+                setAddMode={setAddMode}
+                project={project}
+                setProject={setProject}
+              />
             </GrayBoxContainer>
           )}
+          {project.map((project) => (
+            <GrayBoxContainer key={project.id}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  width: "100%",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    width: "100%",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "2px",
+                    }}
+                  >
+                    <ProjectNameStyle>{project.name}</ProjectNameStyle>
+                    <ProjectSummaryStyle>{project.summary}</ProjectSummaryStyle>
+                  </div>
+                  <div> 스택 두는 곳</div>
+                </div>
+                <Textarea
+                  value={project.description}
+                  readOnly={true}
+                ></Textarea>
+              </div>
+            </GrayBoxContainer>
+          ))}
         </ProjectWrapperStyle>
       )}
     </WrapperStyle>
@@ -119,13 +170,28 @@ const ResumeForm = (props) => {
   const [name, setName] = useState("");
   const [introduction, setIntroduction] = useState("");
   const [project, setProject] = useState([]);
-  function onChangeName(e) {
-    setName(e.target.value);
-  }
 
-  function onChangeIntroduction(e) {
-    setIntroduction(e.target.value);
-  }
+  useEffect(() => {
+    console.log("Project", project);
+  }, [project]);
+
+  const addResume = async () => {
+    const data = {
+      name: name,
+      introduction: introduction,
+      project: project,
+    };
+    try {
+      const res = await axios.post("/resume", data);
+      console.log(res);
+      if (res.status === 201) {
+        alert("이력서 추가 성공");
+        setResumeList(res.data.data);
+      }
+    } catch (e) {
+      alert(e);
+    }
+  };
 
   return (
     <>
@@ -133,17 +199,21 @@ const ResumeForm = (props) => {
         label="이력서 이름"
         color={InputColor.GRAY}
         value={name}
-        handler={onChangeName}
+        onChange={setName}
       />
       <ProjectContainer setProject={setProject} project={project} />
       <Textarea
         label="설명"
         color={TextareaColor.GRAY}
         value={introduction}
-        handler={onChangeIntroduction}
+        onChange={setIntroduction}
       />
       <div style={{ width: "300px" }}>
-        <Button feature={ButtonFeature.NONE} color={ButtonColor.GRAY}>
+        <Button
+          feature={ButtonFeature.NONE}
+          color={ButtonColor.GRAY}
+          handler={addResume}
+        >
           이력서 추가하기
         </Button>
       </div>
@@ -154,7 +224,7 @@ const ResumeForm = (props) => {
 const Resume = () => {
   const [addMode, setAddMode] = useState(false);
 
-  const [info, setInfo] = useState({});
+  const [resumeList, setResumeList] = useState([]);
 
   function onClickAddButton() {
     setAddMode(true);
@@ -189,7 +259,7 @@ const Resume = () => {
         <div style={{ display: "flex", flexDirection: "row", gap: "80px" }}>
           <ListWrapper></ListWrapper>
           <WhiteBoxContainer>
-            {Object.keys(info).length === 0 && !addMode ? (
+            {resumeList.length === 0 && !addMode ? (
               <ImageText
                 imageUrl="images/ic_resume.svg"
                 color={ImageTextColor.BLUE}
@@ -199,7 +269,7 @@ const Resume = () => {
                 이력서를 추가해주세요.
               </ImageText>
             ) : (
-              <ResumeForm addMode={addMode} info={info} setInfo={setInfo} />
+              <ResumeForm addMode={addMode} />
             )}
           </WhiteBoxContainer>
         </div>
@@ -266,8 +336,8 @@ const WhiteBoxContainer = styled.div`
 
 const GrayBoxContainer = styled.div`
   display: flex;
-  width: calc(100% - 32px);
-  padding: 16px;
+  width: calc(100% - 24px);
+  padding: 12px;
   flex-direction: column;
   gap: 20px;
   border-radius: 20px;
@@ -276,8 +346,8 @@ const GrayBoxContainer = styled.div`
   align-items: center;
 `;
 
-const NoProjectContainer = styled.div`
-  fill: #ffffff;
+const NoContentContainer = styled.div`
+  background: #fff;
   border: 1px solid rgba(61, 67, 113, 0.3);
   border-radius: 10px;
   color: rgba(28, 28, 28, 0.7);
@@ -292,4 +362,18 @@ const ProjectWrapperStyle = styled.div`
   flex-direction: column;
   gap: 4px;
   width: 100%;
+`;
+
+const ProjectNameStyle = styled.div`
+  color: rgba(28, 28, 28, 0.7);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.4px;
+`;
+
+const ProjectSummaryStyle = styled.div`
+  color: rgba(61, 67, 113, 0.5);
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: -0.1px;
 `;

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Header from "../components/Header";
@@ -167,6 +168,8 @@ const ProjectContainer = (props) => {
 };
 
 const ResumeForm = (props) => {
+  const { setResumeList } = props;
+
   const [name, setName] = useState("");
   const [introduction, setIntroduction] = useState("");
   const [project, setProject] = useState([]);
@@ -269,7 +272,7 @@ const Resume = () => {
                 이력서를 추가해주세요.
               </ImageText>
             ) : (
-              <ResumeForm addMode={addMode} />
+              <ResumeForm addMode={addMode} setResumeList={setResumeList} />
             )}
           </WhiteBoxContainer>
         </div>

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -238,11 +238,11 @@ const Resume = () => {
       <Header />
       <MainBanner
         badgeText="모의면접 생성"
-        badgeType="outlined"
-        title="Part 1. 어떤 면접인지 입력해 주세요"
-        description="이력서 작성 페이지를 통해 미리 작성할 수 있으며, 선택한 이력서를 바탕으로 질문이 생성됩니다."
+        badgeType="filled"
+        title="자신의 이력서를 정리해 보세요!"
+        description="면접 생성 시 입력한 이력서를 기반으로 면접 질문이 생성됩니다."
         imageUrl="images/ic_resume.svg"
-        bgColor="#3d4371"
+        bgColor="#8D99F3"
       />
       <ContentContainer>
         <div style={{ width: "400px", marginBottom: "20px" }}>

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -2,15 +2,162 @@ import { useState } from "react";
 import styled from "styled-components";
 import Header from "../components/Header";
 import MainBanner from "../components/MainBanner/MainBanner";
-import Button, { ButtonFeature } from "../components/Button/Button";
+import Button, {
+  ButtonColor,
+  ButtonFeature,
+} from "../components/Button/Button";
 import Input, { InputColor } from "../components/Input/Input";
+import { WrapperStyle, LabelStyle } from "../components/Input/style";
 import Textarea, { TextareaColor } from "../components/Textarea/Textarea";
+import ImageText, { ImageTextColor } from "../components/ImageText/ImageText";
+
+const ProjectForm = (props) => {
+  const { setAddMode } = props;
+
+  const [name, setName] = useState("");
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [techStack, setTechStack] = useState([]);
+
+  function onChangeName(e) {
+    setName(e.target.value);
+  }
+
+  function onChangeSummary(e) {
+    setSummary(e.target.value);
+  }
+
+  function onChangeDescription(e) {
+    setDescription(e.target.value);
+  }
+
+  function onClickCloseButton() {
+    setAddMode(false);
+  }
+
+  return (
+    <>
+      <TitleWrapper>
+        <LabelStyle>새 프로젝트 입력</LabelStyle>
+        <Button feature={ButtonFeature.FLEXIBLE} handler={onClickCloseButton}>
+          닫기
+        </Button>
+      </TitleWrapper>
+      <Input
+        label="1. 프로젝트 이름을 입력해주세요"
+        color={InputColor.WHITE}
+        value={name}
+        handler={onChangeName}
+      />
+      <Input
+        label="2. 프로젝트 한 줄 설명을 입력해주세요"
+        color={InputColor.WHITE}
+        value={summary}
+        handler={onChangeSummary}
+      />
+      <div
+        style={{
+          display: "flex",
+          gap: "12px",
+          width: "100%",
+          alignItems: "center",
+        }}
+      >
+        <LabelStyle>3. 사용 스택을 선택해주세요</LabelStyle>
+        <Button feature={ButtonFeature.FLEXIBLE}>스택 검색</Button>
+      </div>
+      <Textarea
+        label="4. 상세 업무 및 성과를 입력해주세요"
+        color={TextareaColor.WHITE}
+        value={description}
+        handler={onChangeDescription}
+      />
+      <div style={{ width: "300px" }}>
+        <Button feature={ButtonFeature.NONE} color={ButtonColor.BLUE}>
+          프로젝트 추가하기
+        </Button>
+      </div>
+    </>
+  );
+};
+
+const ProjectContainer = (props) => {
+  const { project, setProject } = props;
+
+  const [addMode, setAddMode] = useState(false);
+
+  function onClickAddButton() {
+    setAddMode(true);
+  }
+
+  return (
+    <WrapperStyle>
+      <TitleWrapper>
+        <LabelStyle>사이드 프로젝트</LabelStyle>
+        <Button feature={ButtonFeature.FLEXIBLE} handler={onClickAddButton}>
+          사이드 프로젝트 추가
+        </Button>
+      </TitleWrapper>
+      {project.length === 0 && !addMode ? (
+        <NoProjectContainer>
+          입력된 사이드 프로젝트가 없습니다.
+        </NoProjectContainer>
+      ) : (
+        <ProjectWrapperStyle>
+          {addMode && (
+            <GrayBoxContainer>
+              <ProjectForm setAddMode={setAddMode} />
+            </GrayBoxContainer>
+          )}
+        </ProjectWrapperStyle>
+      )}
+    </WrapperStyle>
+  );
+};
+
+const ResumeForm = (props) => {
+  const [name, setName] = useState("");
+  const [introduction, setIntroduction] = useState("");
+  const [project, setProject] = useState([]);
+  function onChangeName(e) {
+    setName(e.target.value);
+  }
+
+  function onChangeIntroduction(e) {
+    setIntroduction(e.target.value);
+  }
+
+  return (
+    <>
+      <Input
+        label="이력서 이름"
+        color={InputColor.GRAY}
+        value={name}
+        handler={onChangeName}
+      />
+      <ProjectContainer setProject={setProject} project={project} />
+      <Textarea
+        label="설명"
+        color={TextareaColor.GRAY}
+        value={introduction}
+        handler={onChangeIntroduction}
+      />
+      <div style={{ width: "300px" }}>
+        <Button feature={ButtonFeature.NONE} color={ButtonColor.GRAY}>
+          이력서 추가하기
+        </Button>
+      </div>
+    </>
+  );
+};
 
 const Resume = () => {
   const [addMode, setAddMode] = useState(false);
 
+  const [info, setInfo] = useState({});
+
   function onClickAddButton() {
-    setAddMode(!addMode);
+    setAddMode(true);
   }
 
   return (
@@ -25,27 +172,35 @@ const Resume = () => {
         bgColor="#3d4371"
       />
       <ContentContainer>
-        <TitleWrapper>
-          <InterviewSettingTitle>
-            나의 이력서
-            <RightArrow
-              src="images/ic_right_arrow.svg"
-              alt="right_arrow_icon"
-            />
-          </InterviewSettingTitle>
-          <Button feature={ButtonFeature.FLEXIBLE} handler={onClickAddButton}>
-            이력서 추가
-          </Button>
-        </TitleWrapper>
+        <div style={{ width: "400px", marginBottom: "20px" }}>
+          <TitleWrapper>
+            <InterviewSettingTitle>
+              나의 이력서
+              <RightArrow
+                src="images/ic_right_arrow.svg"
+                alt="right_arrow_icon"
+              />
+            </InterviewSettingTitle>
+            <Button feature={ButtonFeature.FLEXIBLE} handler={onClickAddButton}>
+              이력서 추가
+            </Button>
+          </TitleWrapper>
+        </div>
         <div style={{ display: "flex", flexDirection: "row", gap: "80px" }}>
-          <ListWrapper>
-            <div style={{ backgroundColor: "gray" }}>목록 1</div>
-            <div style={{ backgroundColor: "gray" }}>목록 2</div>
-            <div style={{ backgroundColor: "gray" }}>목록 3</div>
-          </ListWrapper>
+          <ListWrapper></ListWrapper>
           <WhiteBoxContainer>
-            <Input label="이력서 이름" color={InputColor.GRAY} />
-            <Textarea label="설명" color={TextareaColor.GRAY} />
+            {Object.keys(info).length === 0 && !addMode ? (
+              <ImageText
+                imageUrl="images/ic_resume.svg"
+                color={ImageTextColor.BLUE}
+              >
+                조회할 이력서가 없습니다.
+                <br />
+                이력서를 추가해주세요.
+              </ImageText>
+            ) : (
+              <ResumeForm addMode={addMode} info={info} setInfo={setInfo} />
+            )}
           </WhiteBoxContainer>
         </div>
       </ContentContainer>
@@ -59,14 +214,12 @@ const MainContainer = styled.div`
   display: flex;
   flex-direction: column;
   background-color: #f9fafb;
-  height: 100vh;
 `;
 
 const InterviewSettingTitle = styled.div`
   color: #1c1c1c;
   font-weight: 700;
   font-size: 20px;
-  margin-bottom: 20px;
   display: flex;
   align-items: center;
 `;
@@ -87,7 +240,8 @@ const TitleWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  width: 400px;
+  width: 100%;
+  align-items: center;
 `;
 
 const ListWrapper = styled.div`
@@ -98,6 +252,7 @@ const ListWrapper = styled.div`
 `;
 
 const WhiteBoxContainer = styled.div`
+  width: calc(100% - 400px - 80px - 64px);
   display: inline-flex;
   padding: 32px;
   flex-direction: column;
@@ -106,4 +261,35 @@ const WhiteBoxContainer = styled.div`
   border-radius: 20px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   background: #fff;
+  min-height: 350px;
+`;
+
+const GrayBoxContainer = styled.div`
+  display: flex;
+  width: calc(100% - 32px);
+  padding: 16px;
+  flex-direction: column;
+  gap: 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(61, 67, 113, 0.3);
+  background: rgba(61, 67, 113, 0.03);
+  align-items: center;
+`;
+
+const NoProjectContainer = styled.div`
+  fill: #ffffff;
+  border: 1px solid rgba(61, 67, 113, 0.3);
+  border-radius: 10px;
+  color: rgba(28, 28, 28, 0.7);
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: -0.65px;
+  padding: 10px 12px;
+`;
+
+const ProjectWrapperStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
 `;


### PR DESCRIPTION
**1. Button, Input, Textarea의 letter-spacing 조절**
(피그마 수치와 똑같이 했는데 글자 크기가 작아지면 작아질수록 더 심해지는 경향이 있어서 적절하게 수정)

**2. ImageText 컴포넌트 추가**: 목록에 아무 것도 없을 때 사용하는 띄우는 컴포넌트

**3. Resume 페이지 기능 추가**
- 이력서가 없을 때 화면
- 이력서 추가 버튼 누르면 이력서 폼 보여줌
- 사이드 프로젝트 추가 버튼 누르면 보여주는 사이드 프로젝트 폼에서 프로젝트 추가 가능
- 사이드 프로젝드 추가 닫기 버튼 누르면 폼 사라짐

-> 이후 추가가 필요한 부분: stack 관련, api연결 테스트